### PR TITLE
Added a placeholder implementation of actors dropping weapons by pres…

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Battle_Royal"
-run/main_scene="res://scenes/title_screen.tscn"
+run/main_scene="res://scenes/scene.tscn"
 config/features=PackedStringArray("4.0", "C#", "Forward Plus")
 config/icon="res://sprites/icon.svg"
 
@@ -51,13 +51,14 @@ reload={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
 ]
 }
+drop_weapon={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 
 3d_physics/layer_1="World"
 3d_physics/layer_2="Actors"
 3d_physics/layer_3="Items"
-
-[physics]
-
-common/max_physics_steps_per_frame=16

--- a/project.godot
+++ b/project.godot
@@ -51,7 +51,7 @@ reload={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
 ]
 }
-drop_weapon={
+exchange_weapon={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"echo":false,"script":null)
 ]

--- a/scenes/actor.tscn
+++ b/scenes/actor.tscn
@@ -11,6 +11,7 @@ height = 2.00418
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_ie7wx"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_cgo17"]
+height = 2.58305
 radius = 1.27991
 
 [node name="Actor" type="CharacterBody3D" node_paths=PackedStringArray("held_weapon") groups=["actors"]]
@@ -47,7 +48,7 @@ collision_layer = 0
 collision_mask = 4
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="ItemPickupArea"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.23448, 0)
 shape = SubResource("CylinderShape3D_cgo17")
 
 [connection signal="health_depleted" from="Health" to="." method="_on_health_depleted"]

--- a/scripts/actor_controller.gd
+++ b/scripts/actor_controller.gd
@@ -13,3 +13,6 @@ func is_shooting() -> bool:
 
 func is_reloading() -> bool:
 	return false
+
+func is_dropping_weapon() -> bool:
+	return false

--- a/scripts/actor_controller.gd
+++ b/scripts/actor_controller.gd
@@ -14,5 +14,5 @@ func is_shooting() -> bool:
 func is_reloading() -> bool:
 	return false
 
-func is_dropping_weapon() -> bool:
+func is_exchanging_weapon() -> bool:
 	return false

--- a/scripts/ai/find_weapon_state.gd
+++ b/scripts/ai/find_weapon_state.gd
@@ -3,6 +3,7 @@ extends State
 class_name FindWeaponState
 
 var current_target: Weapon
+var picked_up_weapon_last_tick: bool = false
 
 func enter(_controller: AiActorController):
 	pass
@@ -16,7 +17,11 @@ func execute(controller: AiActorController):
 		controller.state_machine.change_state(FindEnemyState.new())
 
 func execute_physics(controller: AiActorController):
-	if (current_target != null):
+	if (picked_up_weapon_last_tick):
+		picked_up_weapon_last_tick = false
+		controller.set_is_exchanging_weapon(false)
+		controller.state_machine.change_state(FindEnemyState.new())
+	elif (current_target != null):
 		var target_pos = current_target.global_transform.origin
 		controller.nav_agent.target_position = target_pos
 
@@ -28,10 +33,11 @@ func execute_physics(controller: AiActorController):
 		controller.set_aim_position(controller.actor.to_global(Vector3(dir.x * 100, 0, dir.z * 100)))
 
 		var target_distance: float = target_pos.distance_to(controller.actor.global_transform.origin)
-		if target_distance <= 0.1 || controller.actor.held_weapon != null:
-			# weapon has been picked up
-			controller.state_machine.change_state(FindEnemyState.new())
+		var closest_weapon = controller.actor.get_closest_weapon_if_exists()
+		
+		if closest_weapon == current_target:
+			controller.set_is_exchanging_weapon(true)
+			picked_up_weapon_last_tick = true
 
 func exit(controller: AiActorController):
 	controller.set_move_direction(Vector2.ZERO)
-	pass

--- a/scripts/ai_actor_controller.gd
+++ b/scripts/ai_actor_controller.gd
@@ -11,6 +11,7 @@ var move_direction: Vector2 = Vector2.ZERO
 var is_shooting_bool: bool = false
 var is_reloading_bool: bool = false
 var current_target: Actor = null
+var is_exchanging_weapon_bool: bool = false
 
 func _process(delta):
 	state_machine._process(delta)
@@ -46,3 +47,9 @@ func is_reloading() -> bool:
 
 func set_is_reloading(reload: bool):
 	is_reloading_bool = reload
+
+func is_exchanging_weapon() -> bool:
+	return is_exchanging_weapon_bool
+
+func set_is_exchanging_weapon(exchange: bool):
+	is_exchanging_weapon_bool = exchange

--- a/scripts/player_actor_controller.gd
+++ b/scripts/player_actor_controller.gd
@@ -32,5 +32,5 @@ func is_shooting() -> bool:
 func is_reloading() -> bool:
 	return Input.is_action_pressed("reload")
 
-func is_dropping_weapon() -> bool:
-	return Input.is_action_pressed("drop_weapon")
+func is_exchanging_weapon() -> bool:
+	return Input.is_action_pressed("exchange_weapon")

--- a/scripts/player_actor_controller.gd
+++ b/scripts/player_actor_controller.gd
@@ -31,3 +31,6 @@ func is_shooting() -> bool:
 
 func is_reloading() -> bool:
 	return Input.is_action_pressed("reload")
+
+func is_dropping_weapon() -> bool:
+	return Input.is_action_pressed("drop_weapon")

--- a/scripts/world.gd
+++ b/scripts/world.gd
@@ -16,8 +16,8 @@ enum Weapons {SMG, SHOTGUN, SNIPER}
 func _ready():
 	spawn_player(Vector2(0,5))
 	spawn_ai(Vector2(-10,0))
-	spawn_ai(Vector2(-10,5))
-	spawn_ai(Vector2(30,0))
+	#spawn_ai(Vector2(-10,5))
+	#spawn_ai(Vector2(30,0))
 	spawn_weapon(Vector2(5,5), Weapons.SMG)
 	spawn_weapon(Vector2(-15,5), Weapons.SHOTGUN)
 	spawn_weapon(Vector2(25,-5), Weapons.SNIPER)


### PR DESCRIPTION
#11 
Now the player can drop the held weapon by pressing 'G'. In order to pick up the dropped weapon again, the player needs to move away from it, then move back to pick it up.