### PR TITLE
Fixed the occasional crash when changing weapon slots while firing

### DIFF
--- a/scripts/action_system/action_system.gd
+++ b/scripts/action_system/action_system.gd
@@ -6,8 +6,13 @@ extends Node
 
 var action_stacks: Array[ActionStack] = []
 var world: World
-#var frame_count: int = 0
+var frame_count: int = 0
 @export var effect_manager: EffectManager
+
+func _ready():
+	# we want this to execute last in a frame so that there's no chance of
+	# actions being delayed until the next frame
+	process_priority = 999999
 
 func _process(delta):
 	var uncompleted_action_stacks: Array[ActionStack] = []
@@ -19,10 +24,10 @@ func _process(delta):
 			uncompleted_action_stacks.append(action_stack)
 	
 	action_stacks = uncompleted_action_stacks
-	#frame_count += 1
+	frame_count += 1
 
 func action_triggered(action: Action, game_item: GameItem):
-	#print("action triggered at frame %s" % frame_count)
+	#print("action %s triggered at frame %s" % [Action.Name.keys()[action.action_name], frame_count])
 	var duplicated_action = action.duplicate(true)
 	var action_stack = ActionStack.new(game_item, self, world, _add_connections_to_action, duplicated_action)
 	action_stacks.append(action_stack)

--- a/scripts/actor.gd
+++ b/scripts/actor.gd
@@ -63,6 +63,8 @@ func _process(_delta):
 		return
 	
 	cursor.global_position = controller.get_aim_position()
+	if (controller.is_exchanging_weapon()):
+		_try_to_exchange_weapon()
 	
 	if (_drop_weapon_cooldown_timer > 0.0):
 		_drop_weapon_cooldown_timer -= _delta
@@ -77,8 +79,6 @@ func _process(_delta):
 		held_weapon.reload()
 	if (held_weapon != null && held_weapon is Weapon):
 		held_weapon.set_is_moving(!controller.get_move_direction().is_zero_approx())
-	if (controller.is_exchanging_weapon()):
-		_try_to_exchange_weapon()
 	if (!controller.get_move_direction().is_zero_approx()):
 		actor_state = ActorState.WALKING
 		if animation_player.current_animation != "walking":

--- a/scripts/components/inventory/inventory_ui.gd
+++ b/scripts/components/inventory/inventory_ui.gd
@@ -4,6 +4,9 @@ signal selected_slot_scrolled_up
 signal selected_slot_scrolled_down
 var _slots: Array[InventorySlotUi] = []
 
+func _ready():
+	process_priority = -9999 # so that this can trigger inventory changes before the actor's process method is called
+
 func _process(_delta):
 	if Input.is_action_just_pressed("scroll_inventory_up"):
 		selected_slot_scrolled_up.emit()


### PR DESCRIPTION
The crash was caused by a weapon being fired and removed from the world before the ActionSystem was able to process the action generated by the weapon. The fix was to change the process priority of the InventoryUI so that it will be called early, and change the process priority of the ActionSystem so that it will be called last.