### PR TITLE
Got a basic logger script and replaced the existing print statements with logger calls

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/game_scene_root.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://sprites/icon.svg"
 
+[autoload]
+
+Logger="*res://scripts/logger/logger.gd"
+
 [input]
 
 move_left={

--- a/scripts/action_system/action_stack.gd
+++ b/scripts/action_system/action_stack.gd
@@ -31,7 +31,7 @@ func perform(delta: float):
 	while there_are_completable_actions and !is_canceled:
 		var current_action_is_completed: bool
 		
-		#print("performing action %s" % Action.Name.keys()[current_node.action.action_name])
+		Logger.trace("performing action %s" % Action.Name.keys()[current_node.action.action_name])
 		current_action_is_completed = current_node.action.perform(delta, current_node)
 		
 		if current_action_is_completed:

--- a/scripts/action_system/action_system.gd
+++ b/scripts/action_system/action_system.gd
@@ -27,7 +27,7 @@ func _process(delta):
 	frame_count += 1
 
 func action_triggered(action: Action, game_item: GameItem):
-	#print("action %s triggered at frame %s" % [Action.Name.keys()[action.action_name], frame_count])
+	Logger.trace("action %s triggered" % [Action.Name.keys()[action.action_name]])
 	var duplicated_action = action.duplicate(true)
 	var action_stack = ActionStack.new(game_item, self, world, _add_connections_to_action, duplicated_action)
 	action_stacks.append(action_stack)

--- a/scripts/logger/logger.gd
+++ b/scripts/logger/logger.gd
@@ -1,0 +1,40 @@
+class_name LoggerInterface extends Node
+
+# red, yellow, white, green
+enum LoggingLevel {ERROR, WARN, INFO, TRACE}
+
+var logging_level: LoggingLevel = LoggingLevel.TRACE
+
+func log(level: LoggingLevel, message: String) -> void:
+	var msg: String = "[color=%s][%08d] %6s[/color] %s" % [_get_color_for_level(level), Engine.get_process_frames(), _get_level_name(level), message]
+	if level <= logging_level:
+		print_rich(msg)
+
+func error(message: String) -> void:
+	self.log(LoggingLevel.ERROR, message)
+
+func warn(message: String) -> void:
+	self.log(LoggingLevel.WARN, message)
+	
+func info(message: String) -> void:
+	self.log(LoggingLevel.INFO, message)
+	
+func trace(message: String) -> void:
+	self.log(LoggingLevel.TRACE, message)
+
+func _get_color_for_level(level: LoggingLevel) -> String:
+	match level:
+		LoggingLevel.ERROR:
+			return "red"
+		LoggingLevel.WARN:
+			return "yellow"
+		LoggingLevel.INFO:
+			return "white"
+		LoggingLevel.TRACE:
+			return "green"
+		_:
+			assert(false, "Invalid logging level %s" % [level])
+			return "red" # will not execute due to the assert call
+
+func _get_level_name(level: LoggingLevel) -> String:
+	return LoggingLevel.keys()[level]

--- a/scripts/world.gd
+++ b/scripts/world.gd
@@ -24,6 +24,7 @@ signal game_loaded
 func _ready():
 	action_system.world = self
 	set_camera_to_default()
+	Logger.logging_level = Logger.LoggingLevel.TRACE
 
 func _process(_delta):
 	if Input.is_action_pressed("zoom_out"):


### PR DESCRIPTION
This adds a basic logger script that is autoloaded.
The logging levels are as follows, from most granular to least:
1. TRACE
2. INFO
3. WARN
4. ERROR
Where TRACE is intended for debugging small parts of the program, and ERROR is for large issues, such as a critical class instance not being present.
The logger's printing level can be changed at any time by calling `Logger.logging_level = Logger.LoggingLevel.{logging level goes  here}`