### PR TITLE
Apply default Godot project changes on 4.5 to 4.6

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -8,11 +8,15 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="Battle_Royal"
 run/main_scene="res://scenes/game_scene_root.tscn"
-config/features=PackedStringArray("4.5", "Forward Plus")
+config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://sprites/icon.svg"
 
 [autoload]


### PR DESCRIPTION
Nothing special here, these are the default changes applied when opening a project in 4.6 for the first time from 4.5.